### PR TITLE
Allow x-name to be used from cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,15 @@ await checkIfNameIsAvailable("abc"); // false
 await checkIfNameIsAvailable("your-package-name"); // true
 ```
 
+Or install using
+```bash
+deno install --allow-net -n x-name https://deno.land/x/x_name/mod.ts
+```
+And run with 
+```bash
+x-name <name of the package>
+```
+
 Required permissions:
 
 1. `--allow-net`

--- a/README.md
+++ b/README.md
@@ -11,13 +11,18 @@ await checkIfNameIsAvailable("abc"); // false
 await checkIfNameIsAvailable("your-package-name"); // true
 ```
 
+alternatively you can use it directly fron cli by using `deno run`:
+```bash
+deno run --allow-net https://deno.land/x/x_name/mod.ts <your-package-name>
+```
+
 Or install using
 ```bash
 deno install --allow-net -n x-name https://deno.land/x/x_name/mod.ts
 ```
 And run with 
 ```bash
-x-name <name of the package>
+x-name <your-package-name>
 ```
 
 Required permissions:

--- a/mod.ts
+++ b/mod.ts
@@ -10,3 +10,7 @@ export async function checkIfNameIsAvailable(name: string) {
   }
   return !database.includes(name);
 }
+
+for (let arg of Deno.args) {
+  console.log(arg, await checkIfNameIsAvailable(arg) ? "is available" : "is taken");
+}


### PR DESCRIPTION
Now you should be able to use `deno run --allow-net https://deno.land/x/x_name/mod.ts <name of the package>` or `deno install --allow-net -n x-name https://deno.land/x/x_name/mod.ts` and `x-name <name of the package` to check if the name is available without creating a new script or using deno repl.

It can take an arbitrary number of arguments and check each for appearance `database.json`.

Returns `<argument> is available` or `<argument> is taken` for each argument
